### PR TITLE
fix(hooks): optimize useProjectUsers hook

### DIFF
--- a/src/hooks/useProjectUsers.tsx
+++ b/src/hooks/useProjectUsers.tsx
@@ -32,8 +32,8 @@ type HookConfig = {
   apiVersion?: string
 }
 
-function chunkArray(array: any[], size: number) {
-  const chunks = []
+function chunkArray<T>(array: T[], size: number): T[][] {
+  const chunks: T[][] = []
   for (let i = 0; i < array.length; i += size) {
     chunks.push(array.slice(i, i + size))
   }

--- a/src/hooks/useProjectUsers.tsx
+++ b/src/hooks/useProjectUsers.tsx
@@ -1,4 +1,4 @@
-import {useState, useEffect} from 'react'
+import {useEffect, useState} from 'react'
 import {useClient, useWorkspace} from 'sanity'
 
 export type UserExtended = {
@@ -32,40 +32,62 @@ type HookConfig = {
   apiVersion?: string
 }
 
-// Custom hook to fetch user details
-// Built-in hook doesn't fetch all user details
+function chunkArray(array: any[], size: number) {
+  const chunks = []
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size))
+  }
+  return chunks
+}
+
+// Custom hook to fetch user details and roles in batches
 export function useProjectUsers({apiVersion}: HookConfig): UserExtended[] {
   const {currentUser} = useWorkspace()
   const client = useClient({apiVersion: apiVersion ?? '2023-01-01'})
-  const [users, setUsers] = useState([])
+  const [users, setUsers] = useState<UserExtended[]>([])
 
   useEffect(() => {
     const {projectId} = client.config()
 
-    async function getUser(id: string) {
-      const userDetails = await client.request({
-        url: `/projects/${projectId}/users/${id}`,
-      })
-
-      return userDetails
-    }
-
     async function getUsersWithRoles() {
-      const userRoles = await client
-        .request({
+      try {
+        const aclData = await client.request({
           url: `/projects/${projectId}/acl`,
         })
-        .then(async (res) =>
-          Promise.all(
-            res.map(async (user: UserResponse) => ({
-              isCurrentUser: user.projectUserId === currentUser?.id,
-              ...(await getUser(user.projectUserId)),
-            }))
-          )
-        )
-        .catch((err) => err)
 
-      setUsers(userRoles)
+        const userIds = aclData.map((user: UserResponse) => user.projectUserId)
+
+        const userIdChunks = chunkArray(userIds, 200)
+
+        let usersData: UserExtended[] = []
+
+        // Fetch users in batches of 200
+        for (const chunk of userIdChunks) {
+          const chunkedUserIds = chunk.join(',')
+          const response = await client.request({
+            url: `/projects/${projectId}/users/${chunkedUserIds}`,
+          })
+          usersData = [...usersData, ...response]
+        }
+
+        // Combine user details with roles
+        const usersWithRoles = usersData.map((user: UserExtended) => {
+          const userRoles =
+            aclData.find(
+              (aclUser: UserResponse) => aclUser.projectUserId === user.id
+            )?.roles || []
+
+          return {
+            ...user,
+            isCurrentUser: user.id === currentUser?.id,
+            roles: userRoles,
+          }
+        })
+
+        setUsers(usersWithRoles)
+      } catch (err) {
+        console.error('Failed to fetch users:', err)
+      }
     }
 
     if (!users.length) {


### PR DESCRIPTION
We ran into performance issues with a project with lots of users.

Improved to fetch users in batches instead of one by one

Since this is used by the workflow example, it could be good to update